### PR TITLE
Fix #27 remove unneeded old mail settings / set email queue settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,10 @@ PYTHON_VENV_DIRECTORY="/path/to/venv"
 
 PYTHON_PATH_INJECT=/path/to/subscribie/
 EMAIL_LOGIN_FROM="noreply@example.com"                                           
-MAIL_SERVER="email.example.com"                                                  
-MAIL_USERNAME="noreply@example.com"                                              
-MAIL_PASSWORD="password"                                                         
-MAIL_USE_TLS="True"                                                              
-MAIL_PORT="25"
+# For EMAIL_QUEUE_FOLDER
+# See https://github.com/Subscribie/subscribie/issues/671
+# and https://github.com/KarmaComputing/send-email-asynchronously
+EMAIL_QUEUE_FOLDER="/var/email-queue"
 
 # Stripe connect api keys (not keys of shop owner)
 STRIPE_LIVE_SECRET_KEY=

--- a/main.py
+++ b/main.py
@@ -174,35 +174,16 @@ def deploy():
 
         # Update .env values for mail
         subprocess.call(
-            f"dotenv -f {envFileDst} set MAIL_SERVER {app.config['MAIL_SERVER']}",  # noqa: E501
-            shell=True,
-        )
-        subprocess.call(
-            f"dotenv -f {envFileDst} set MAIL_PORT {app.config['MAIL_PORT']}",
-            shell=True,
-        )
-        subprocess.call(
-            f"dotenv -f {envFileDst} set MAIL_PORT {app.config['MAIL_PORT']}",
-            shell=True,
-        )
-        subprocess.call(
-            f"dotenv -f {envFileDst} set MAIL_USERNAME {app.config['MAIL_USERNAME']}",  # noqa: E501
-            shell=True,
-        )
-        subprocess.call(
-            f"dotenv -f {envFileDst} set MAIL_PASSWORD {app.config['MAIL_PASSWORD']}",  # noqa: E501
-            shell=True,
-        )
-        subprocess.call(
             f"dotenv -f {envFileDst} set MAIL_DEFAULT_SENDER {app.config['EMAIL_LOGIN_FROM']}",  # noqa: E501
             shell=True,
         )
         subprocess.call(
-            f"dotenv -f {envFileDst} set MAIL_USE_TLS {app.config['MAIL_USE_TLS']}",  # noqa: E501
+            f"dotenv -f {envFileDst} set EMAIL_LOGIN_FROM {app.config['EMAIL_LOGIN_FROM']}",  # noqa: E501
             shell=True,
         )
+
         subprocess.call(
-            f"dotenv -f {envFileDst} set EMAIL_LOGIN_FROM {app.config['EMAIL_LOGIN_FROM']}",  # noqa: E501
+            f"dotenv -f {envFileDst} set EMAIL_QUEUE_FOLDER {app.config['EMAIL_QUEUE_FOLDER']}",  # noqa: E501
             shell=True,
         )
 


### PR DESCRIPTION
Adds the env settings needed for email queue during new shop deployments

See https://github.com/Subscribie/subscribie/pull/672